### PR TITLE
Fix Access Control Lists Website ALC to ACL

### DIFF
--- a/docs/acl.md
+++ b/docs/acl.md
@@ -1,6 +1,6 @@
 ---
 id: acl
-title: Using Access Control Lists (ALC)
+title: Using Access Control Lists (ACL)
 sidebar_label: Access Control Lists
 ---
 


### PR DESCRIPTION
The Website ```https://docs.keydb.dev/docs/acl/```
Show the Access Control Lists (ALC)
May that abbreviation is ACL
Tks!

Signed-off-by: ZhengSheng0524 <j13tw@yahoo.com.tw>